### PR TITLE
Couple of improvements from BMS fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/example_files
 docs/example_files
 docs/images/loader.gif
 docs/images/search-icon.png
+/.idea/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.DS_Store
+/.idea/

--- a/example_src/forward.html
+++ b/example_src/forward.html
@@ -3,13 +3,13 @@
 <form class="form-inline" style="padding:10px;">
   <div class="form-group">
     <label for="endpoint">BrAPI Base URL</label>
-      <input type="text" class="form-control" id="endpoint" value="http://localhost:7080/brapi/v2">
+    <input type="text" class="form-control" id="endpoint" value="https://test-server.brapi.org/brapi/v1/">
   </div>
 </form>
 <form class="form-inline" style="padding:10px;">
   <div class="form-group">
     <label for="studyDbId">StudyDbId</label>
-      <input type="text" class="form-control" id="studyDbId" value="165">
+    <input type="text" class="form-control" id="studyDbId" value="13">
   </div>
   <a class="btn btn-default" onclick="fieldMap.setLocation(d3.select('#studyDbId').node().value)">Set location</a>
 </form>

--- a/example_src/scripts.html
+++ b/example_src/scripts.html
@@ -19,5 +19,13 @@
     setupBrAPI();
     fieldMap.update().then((resp)=>alert(resp), (resp)=>alert(resp));
   }
-  var fieldMap = new BrAPIFieldmap("#map", d3.select('#endpoint').node().value);
+
+  let brapi_endpoint = d3.select('#endpoint').node().value;
+  const brapi = BrAPI(brapi_endpoint, "1.3");
+  brapi.studies().all((data)=> {
+    if (!data || !data.length) return;
+    d3.select('#studyDbId').node().value = data[0].studyDbId;
+  });
+
+  var fieldMap = new BrAPIFieldmap("#map", brapi_endpoint);
 </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solgenomics/brapi-fieldmap",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "Tool for generating Fieldmap.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "d3": "^5.7.0",
     "leaflet": "^1.5.1",
     "leaflet-path-transform": "^1.1.2",
-    "leaflet-search": "^2.9.8",
+    "leaflet-search": "^2.9.8"
   },
   "devDependencies": {
     "@solgenomics/brapp-wrapper": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Tool for generating Fieldmap.",
   "main": "index.js",
   "dependencies": {
-    "leaflet-search": "^2.9.8",
-    "npm": "^6.4.0",
-    "rollup": "^0.66.2"
-  },
-  "devDependencies": {
     "@solgenomics/brapijs": "^1.0.1",
-    "@solgenomics/brapp-wrapper": "^1.1.0",
     "@turf/turf": "^5.1.6",
     "d3": "^5.7.0",
     "leaflet": "^1.5.1",
     "leaflet-path-transform": "^1.1.2",
+    "leaflet-search": "^2.9.8",
+  },
+  "devDependencies": {
+    "@solgenomics/brapp-wrapper": "^1.1.0",
+    "rollup": "^0.66.2",
+    "npm": "^6.4.0",
     "rollup-plugin-commonjs": "^9.1.8",
     "rollup-plugin-node-resolve": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solgenomics/brapi-fieldmap",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0",
   "description": "Tool for generating Fieldmap.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solgenomics/brapi-fieldmap",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Tool for generating Fieldmap.",
   "main": "index.js",
   "dependencies": {

--- a/src/Fieldmap.js
+++ b/src/Fieldmap.js
@@ -273,7 +273,7 @@ export default class Fieldmap {
         .each(ou=>{
           ou.X = parseFloat(ou.X);
           ou.Y = parseFloat(ou.Y);
-          if(ou.observationLevel.toUpperCase("PLOT")) results.plots.push(ou);
+          if(ou.observationLevel.toUpperCase() === "PLOT") results.plots.push(ou);
           this.data_parsed+=1;
           this.data_total = ou.__response.metadata.pagination.totalCount;
         })


### PR DESCRIPTION
- Move libraries from `devDependencies` to `dependencies`. This is needed if you include the library as an npm dependency, so that it installs all the dependencies too (which you'll need to then move manually according to your needs)
- Add  `.npmignore`: needed if you [include the library from git](https://github.com/IntegratedBreedingPlatform/Workbench/blob/efe36d410c407ac4171f0683300626ef884c5d5d/src/main/web/package.json#L45), otherwise npm won't run `npm prepare`  after `npm install`
- Use brapi tester server in the example. This way at least the example is self contained and can be run by someone interested to see what this is about. It get's the first studyDbId returned by `/studies` and set it in the input. @BrapiCoordinatorSelby

![brapi-fieldmap-test-server](https://user-images.githubusercontent.com/19394293/79620397-203e2b00-80e6-11ea-9d92-1e203ddd11f5.png)
Not very exciting but..

- Bump the patch version: @MFlores2021 Let me know if these changes could affect your setup, I believe they shouldn't

cc @lukasmueller 